### PR TITLE
Improve delgation from class to default client. Drop support of Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 notifications:
   email: false
 rvm:
-- 1.9.3
 - 2.0.0
 - 2.1
 - 2.2

--- a/lib/centrifuge.rb
+++ b/lib/centrifuge.rb
@@ -18,14 +18,9 @@ module Centrifuge
 
     def_delegators :default_client, :scheme, :host, :port, :secret
     def_delegators :default_client, :scheme=, :host=, :port=, :secret=
-
-    # def_delegators :default_client, :authentication_token, :url
-    # def_delegators :default_client, :encrypted=, :url=
-    def_delegators :default_client, :timeout=, :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=
-
-    # def_delegators :default_client, :get, :get_async, :post, :post_async
-    def_delegators :default_client, :publish
-    # def_delegators :default_client, :webhook, :channel, :[]
+    def_delegators :default_client, :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=
+    def_delegators :default_client, :broadcast, :publish, :unsubscribe, :disconnect, :presence, :history, :channels, :stats
+    def_delegators :default_client, :token_for, :generate_channel_sign
 
     attr_writer :logger
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'securerandom'
 
 describe Centrifuge::Client do
   let(:options) { { scheme: :https, host: 'centrifugo.herokuapp.com', port: 443, secret: 'secret' } }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -50,3 +50,26 @@ describe Centrifuge::Client do
     it { expect(result).to eq 'be26ac57ef264c23662ba373e4b68670c1a006431c763af6d33ad10ab6aa97d9' }
   end
 end
+
+describe Centrifuge do
+  context 'delegation' do
+    it 'class should delegate methods to default client' do
+      client_double = double('default_client')
+      methods_to_delegate = [:scheme, :host, :port, :secret,
+        :scheme=, :host=, :port=, :secret=,
+        :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=,
+        :broadcast, :publish, :unsubscribe, :disconnect, :presence, :history,
+        :channels, :stats, :token_for, :generate_channel_sign]
+
+      methods_to_delegate.each do |method|
+        expect(client_double).to receive(method)
+      end
+
+      Centrifuge.stub(:default_client).and_return(client_double)
+
+      methods_to_delegate.each do |method|
+        Centrifuge.send(method)
+      end
+    end
+  end
+end


### PR DESCRIPTION
It allows to call all public methods from default client using `Centrifuge` class.
Also, I found that there is no `timeout=` method, so i remove a delegation. 