### PR TITLE
Weaken Faraday dependency

### DIFF
--- a/cent.gemspec
+++ b/cent.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '<2.0.0', '~> 1.7.0'
+  spec.add_dependency 'faraday', '<2.0.0', '> 1.0.0'
   spec.add_dependency 'faraday_middleware', '<2.0.0', '~> 1.0'
   spec.add_dependency 'jwt', '~> 2.2.1'
 end

--- a/lib/cent/version.rb
+++ b/lib/cent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cent
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
Faraday is a widely popular HTTP library in Ruby. We should weaken its version restrictions to the bare minimum.