### PR TITLE
Loosen JWT dependency version requirement

### DIFF
--- a/cent.gemspec
+++ b/cent.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '<2.0.0', '> 1.0.0'
   spec.add_dependency 'faraday_middleware', '<2.0.0', '~> 1.0'
-  spec.add_dependency 'jwt', '~> 2.2.1'
+  spec.add_dependency 'jwt', '~> 2.2'
 end


### PR DESCRIPTION
JWT 2.3 was released some time ago. Let projects using `cent` gem to use newest version.
