### PR TITLE
Increase Faraday dependency's maximum version to 3.0.0

### DIFF
--- a/cent.gemspec
+++ b/cent.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '<2.0.0', '> 1.0.0'
+  spec.add_dependency 'faraday', '<3.0.0', '> 1.0.0'
+  # NOTE: Remove `faraday_middleware` after changing `faraday`'s minimum version to `2.0.0`.
   spec.add_dependency 'faraday_middleware', '<2.0.0', '~> 1.0'
   spec.add_dependency 'jwt', '~> 2.2'
 end

--- a/lib/cent/client.rb
+++ b/lib/cent/client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday_middleware' if Gem::Version.new(Faraday::VERSION) <= Gem::Version.new('2.0.0')
 require 'cent/http'
 
 module Cent

--- a/spec/cent/client_spec.rb
+++ b/spec/cent/client_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe Cent::Client do
   let(:client) { described_class.new(api_key: 'api_key') }
 
   before do
+    request_headers = {
+      'Content-Type' => 'application/json',
+      'Authorization' => 'apikey api_key'
+    }
+    response_headers = { 'Content-Type' => 'application/json' }
     stub_request(:post, 'http://localhost:8000/api')
-      .with(body: params, headers: {
-              'Content-Type' => 'application/json',
-              'Authorization' => 'apikey api_key'
-            })
-      .to_return(status: 200, body: expected_body)
+      .with(body: params, headers: request_headers)
+      .to_return(status: 200, body: expected_body, headers: response_headers)
   end
 
   describe 'error handling' do


### PR DESCRIPTION
Faraday has [deprecated](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-middleware-deprecation) its middleware gem since version 2.0.0 and introduced a new built-in JSON middleware. (Which is the only middleware used by rubycent.)

This pull request:

- Updates Faraday's dependency version to allow using the latest version.

- Requires the middleware gem only if Faraday's version is older than 2.0.0. (The middleware gem can be removed in the future after changing Faraday dependency's minimum version to 2.0.0.)

- Fixes a failing test with Faraday versions 2.x. See the commit message of https://github.com/centrifugal/rubycent/commit/450ed404b7dda244106e2287d1e1153d79a5fb36 for a detailed explanation.