### PR TITLE
Fix robocop be_nil issue

### DIFF
--- a/spec/cent_spec.rb
+++ b/spec/cent_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Cent do
   it 'has a version number' do
-    expect(Cent::VERSION).not_to be nil
+    expect(Cent::VERSION).not_to be_nil
   end
 
   describe 'Cent::Client' do


### PR DESCRIPTION
Fixes be nil check error in CI observed in https://github.com/centrifugal/rubycent/runs/8069976737?check_suite_focus=true