### PR TITLE
Make it compatible with Ruby 3

### DIFF
--- a/lib/cent/http.rb
+++ b/lib/cent/http.rb
@@ -39,7 +39,7 @@ module Cent
     def post(body: nil)
       response = connection.post(nil, body)
 
-      raise ResponseError, response.body['error'].transform_keys(&:to_sym) if response.body.key?('error')
+      raise ResponseError.new(**response.body['error'].transform_keys(&:to_sym)) if response.body.key?('error')
 
       response.body
     end


### PR DESCRIPTION
`ResponseError` exception was created passing a hash as single argument. The exception class expects 2 keyword arguments. Before Ruby 3.0 it was working fine because Ruby automatically converted a hash to keyword args.

Starting from Ruby 3.0 a double splat operator is required otherwise the entire hash it treated as single positional argument.

Before this fix both specs and production code failed with:
```
ArgumentError: wrong number of arguments (given 1, expected 0; required keywords: code, message)
```