### PR TITLE
Make channel tokens be compatible with Centrifugo v4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All channels starting with $ considered private and require a **channel token** 
 Private channel subscription token is also JWT([see the claims](https://centrifugal.github.io/centrifugo/server/private_channels/))
 
 ```ruby
-notary.issue_channel_token(client: 'client', channel: 'channel', exp: 1629050099, info: { scope: 'admin' }) 
+notary.issue_channel_token(sub: '42', channel: 'channel', exp: 1629050099, info: { scope: 'admin' }) 
 
 #=> "eyJhbGciOiJIUzI1NiJ9..."
 ```

--- a/lib/cent/notary.rb
+++ b/lib/cent/notary.rb
@@ -57,8 +57,8 @@ module Cent
 
     # Generate JWT for private channels
     #
-    # @param client [String]
-    #   Client ID which wants to subscribe on channel
+    # @param sub [String]
+    #   Standard JWT claim which must contain an ID of current application user.
     #
     # @option channel [String]
     #   Channel that client tries to subscribe to (string).
@@ -71,16 +71,16 @@ module Cent
     #   client connection that can be provided for Centrifugo.
     #
     # @example Get private channel JWT with expiration and extra info
-    #   notary.issue_channel_token(client: 'client', channel: 'channel', exp: 3600, info: { 'message' => 'wat' })
+    #   notary.issue_channel_token(sub: '1', channel: 'channel', exp: 3600, info: { 'message' => 'wat' })
     #     #=> eyJhbGciOiJIUzI1NiJ9.eyJjbGllbnQiOiJjbG..."
     #
     # @see (https://centrifugal.github.io/centrifugo/server/private_channels/)
     #
     # @return [String]
     #
-    def issue_channel_token(client:, channel:, info: nil, exp: nil)
+    def issue_channel_token(sub:, channel:, info: nil, exp: nil)
       payload = {
-        'client' => client,
+        'sub' => sub,
         'channel' => channel,
         'info' => info,
         'exp' => exp

--- a/spec/cent/notary_spec.rb
+++ b/spec/cent/notary_spec.rb
@@ -83,21 +83,21 @@ RSpec.describe Cent::Notary do
 
   describe '#issue_channel_token' do
     subject(:channel_token) do
-      notary.issue_channel_token(client: 'client', channel: 'channel', info: { 'foo' => 'bar' })
+      notary.issue_channel_token(sub: '1', channel: 'channel', info: { 'foo' => 'bar' })
     end
 
     let(:notary) { described_class.new(secret: 'secret') }
 
     context 'with no expiration' do
-      it { expect(channel_token).to match(/^eyJhbGciOiJIUzI1NiJ9.*SopvNY$/) }
+      it { expect(channel_token).to match(/^eyJhbGciOiJIUzI1NiJ9.*50TnzY$/) }
     end
 
     context 'with expiration' do
       subject(:channel_token) do
-        notary.issue_channel_token(client: 'client', channel: 'channel', info: { 'foo' => 'bar' }, exp: 1_628_877_060)
+        notary.issue_channel_token(sub: '1', channel: 'channel', info: { 'foo' => 'bar' }, exp: 1_628_877_060)
       end
 
-      it { expect(channel_token).to match(/^eyJhbGciOiJIUzI1NiJ9.*uQCqas$/) }
+      it { expect(channel_token).to match(/^eyJhbGciOiJIUzI1NiJ9.*yht5hk$/) }
     end
 
     context 'with RSA key' do


### PR DESCRIPTION
Hello. I have discovered that if rubycent version 3.0.0 is being used against Centrifugo server versions 4+ (tested with centrifugo server 4.1.5 and 5.4.6, and centrifuge v5.2.2 nodejs module) then channel tokens issued with the help of `client` parameter do not allow subscribing to channels. Debug log in centrifugo server in this case looks like this:
```
2024-10-30 17:57:12 [INF] starting Centrifugo engine=memory gomaxprocs=8 pid=237467 runtime=go1.23.2 version=5.4.6
2024-10-30 17:57:12 [INF] using config file path=/home/centrifugo/config.json
2024-10-30 17:57:12 [INF] enabled JWT verifiers algorithms="HS256, HS384, HS512"
2024-10-30 17:57:12 [INF] serving websocket, api, admin endpoints on :8000
2024-10-30 18:13:22 [DBG] http request addr=[::1]:42912 duration="94.323µs" method=GET path=/connection/websocket status=101
2024-10-30 18:13:22 [DBG] client connection established client=10fd032f-697d-469d-90a9-79983e79f70a transport=websocket
2024-10-30 18:13:22 [DBG] client authenticated client=10fd032f-697d-469d-90a9-79983e79f70a user=user__33
2024-10-30 18:13:22 [INF] token user mismatch channel=foo client=10fd032f-697d-469d-90a9-79983e79f70a tokenUser= user=user__33
2024-10-30 18:13:22 [INF] token user mismatch channel=$user#user__33 client=10fd032f-697d-469d-90a9-79983e79f70a tokenUser= user=user__33
2024-10-30 18:13:22 [DBG] client connection completed client=10fd032f-697d-469d-90a9-79983e79f70a duration=268.267833ms transport=websocket
2024-10-30 18:13:22 [DBG] closing client connection client=10fd032f-697d-469d-90a9-79983e79f70a reason="invalid token" user=user__33
```
After applying changes in this PR (so basically you just need to use `sub` instead of `client` in payload sent to `JWT.encode`, just like for connection tokens) I can successfully subscribe to channels:
```
2024-10-30 18:37:06 [DBG] http request addr=[::1]:59212 duration="86.397µs" method=GET path=/connection/websocket status=101
2024-10-30 18:37:06 [DBG] client connection established client=9a4d9a8b-0de0-4c9c-bf76-823f7a88ffa7 transport=websocket
2024-10-30 18:37:06 [DBG] client authenticated client=9a4d9a8b-0de0-4c9c-bf76-823f7a88ffa7 user=user__33
2024-10-30 18:37:06 [DBG] client subscribed to channel channel=foo client=9a4d9a8b-0de0-4c9c-bf76-823f7a88ffa7 user=user__33
2024-10-30 18:37:06 [DBG] client subscribed to channel channel=$user#user__33 client=9a4d9a8b-0de0-4c9c-bf76-823f7a88ffa7 user=user__33
```
If everything is ok and I'm not missing anything, could you please review, merge the PR and release a new version to rubygems ?