### PR TITLE
Faraday and jwt gems dependencies are relaxes

### DIFF
--- a/cent.gemspec
+++ b/cent.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '<3.0.0', '> 2.0.0'
-  spec.add_dependency 'jwt', '<3.0.0', '> 2.2.0'
+  spec.add_dependency 'faraday', '> 2.0.0'
+  spec.add_dependency 'jwt', '> 2.2.0'
 end


### PR DESCRIPTION
JWT v3 should work in notary gem because only uses JWT.encode